### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: "3.6"
+          python-version: "3.7"
 
       - name: Upgrade pip
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=REQUIRES,
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -36,7 +36,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, lint, mypy
+envlist = py37, py38, py39, py310, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.6: py36, lint, mypy
-  3.7: py37
+  3.7: py37, lint, mypy
   3.8: py38
   3.9: py39
   3.10: py310


### PR DESCRIPTION
- Python 3.6 will be end of life on 23 Dec 2021.